### PR TITLE
Set current page after processing destination

### DIFF
--- a/PdfViewer.cs
+++ b/PdfViewer.cs
@@ -2704,6 +2704,7 @@ namespace Patagames.Pdf.Net.Controls.WinForms
                     ScrollToPoint(pdfDestination.PageIndex, new PointF(left, top));
                     break;
             }
+            CalcAndSetCurrentPage();
             Invalidate();
         }
 


### PR DESCRIPTION
Otherwise the wrong pages is current after navigating with bookmarks or links.